### PR TITLE
tests: fix the spawner assertion

### DIFF
--- a/tests/spawner.c
+++ b/tests/spawner.c
@@ -10,7 +10,9 @@ run_cb (GObject *source, GAsyncResult *res, gpointer data)
   if (error) {
     g_print ("Error: %s\n", error->message);
     g_clear_error (&error);
-    g_test_fail ();
+  } else {
+    /* the second script always fails */
+    g_assert_not_reached ();
   }
   g_main_loop_quit (data);
 }


### PR DESCRIPTION
Actually the test was designed to fail (script2 always fails), hence the validation must be if it doesn't fail. This patch fixes taht.
