### PR TITLE
Add extra check for symbolic links during the cleanup process

### DIFF
--- a/src/eam-fs-sanity.c
+++ b/src/eam-fs-sanity.c
@@ -221,6 +221,22 @@ eam_fs_sanity_delete (const gchar *path)
     g_assert (path);
 
     GFile *file = g_file_new_for_path (path);
+
+    /* Check for symlinks first, to make an early decision if possible */
+    GFileInfo *file_info = g_file_query_info(file, G_FILE_ATTRIBUTE_STANDARD_IS_SYMLINK,
+                                             G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, NULL, &error);
+    if (error) {
+      g_print ("Failure when cleaning the test: %s\n", error->message);
+      g_clear_error (&error);
+      goto bail;
+    }
+
+    gboolean file_is_symlink = g_file_info_get_is_symlink (file_info);
+    g_object_unref (file_info);
+    if (file_is_symlink)
+      goto delete;
+
+    /* Now we can iterate over the children with NO_FOLLOW_LINKS safely */
     GFileEnumerator *children = g_file_enumerate_children (file, G_FILE_ATTRIBUTE_STANDARD_NAME,
                                                            G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
                                                            NULL, &error);


### PR DESCRIPTION
When using G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS together with
g_file_enumerate_children() we can get misleading error codes
G_IO_ERROR_NOT_FOUND for symbolic links, which would lead us to think
that there's no file to delete when there's actually one: the link.

Adding this extra check even before retrieving a list of children and
removing the file from disk if we realize the current file is a
symbolic link prevents the 'make check' process from failing because of
leftovers inside the 'eam-test' directory.
