### PR TITLE
Convert g_print() to g_warning() and fix wrong error message.

### DIFF
--- a/src/eam-fs-sanity.c
+++ b/src/eam-fs-sanity.c
@@ -226,7 +226,7 @@ eam_fs_sanity_delete (const gchar *path)
     GFileInfo *file_info = g_file_query_info(file, G_FILE_ATTRIBUTE_STANDARD_IS_SYMLINK,
                                              G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, NULL, &error);
     if (error) {
-      g_print ("Failure when cleaning the test: %s\n", error->message);
+      g_warning ("Failure querying information for file '%s': %s\n", path, error->message);
       g_clear_error (&error);
       goto bail;
     }


### PR DESCRIPTION
The g_print() and the wrong message comes from a patch for
tests/scripts-install.c, where this function used to live.
