### PR TITLE
Change the ListAvailable return value

### DIFF
--- a/data/eam-dbus-interface.xml
+++ b/data/eam-dbus-interface.xml
@@ -30,6 +30,7 @@
     -->
     <signal name="AvailableApplicationsChanged">
       <arg type="a(sss)" direction="out" />
+      <arg type="a(sss)" direction="out" />
     </signal>
 
     <!--
@@ -73,14 +74,13 @@
     <!--
 	ListAvailable:
 
-        Returns a list of all applications available (including those not yet
-        installed on user’s machine)
+        Returns a list of all applications available for installation
+        and for updates.
     -->
     <method name="ListAvailable" >
       <annotation name="org.freedesktop.DBus.GLib.Async" value="" />
-      <arg type="a(sss)" direction="out">
-	<annotation name="org.freedesktop.DBus.GLib.ReturnVal" value="error" />
-      </arg>
+      <arg type="a(sss)" direction="out" />
+      <arg type="a(sss)" direction="out" />
     </method>
 
     <!--

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -118,11 +118,11 @@ Updates the locally stored list of application with data from the Endless
 server
 
 
-ListAvailable () -> as available_applications
+ListAvailable () -> (a(sss)a(sss))
 ---------------------------------------------
 
-Returns a list of all applications available (including those not yet
-installed on user’s machine)
+Returns the installable applications and the updatable applications, as
+two arrays of (id, name, version) tuples.
 
 
 GetState()


### PR DESCRIPTION
Instead of coalescing all the installable and updatable applications we
should return two disting tuples. This way the app store can store the
data separately and match the correct information.

We need to change the ListAvailable method as well as the
AvailableApplicationsChanged signal, since they both have the same
signature.

[endlessm/eos-shell#2691]
