### PR TITLE
Handle external components

### DIFF
--- a/scripts/install/run/10-extract.sh
+++ b/scripts/install/run/10-extract.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #
-# $ ./01-extract.sh <app_id> <bundle_file_path> ...
+# $ ./10-extract.sh <app_id> <bundle_file_path> ...
 #
 # Parameters:
 # <app_id>: ID of the application to install.
@@ -33,4 +33,3 @@ BUNDLE=$2
 
 verify_downloaded_file "${BUNDLE}" "${APP_ID}.sha256" "${APP_ID}.asc"
 extract_file_to_dir "${BUNDLE}" "${EAM_TMP}"
-mv "${EAM_TMP}/${APP_ID}" "${EAM_PREFIX}"

--- a/scripts/install/run/20-external.sh
+++ b/scripts/install/run/20-external.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -e
+
+# Copyright 2014 Endless Mobile, Inc.
+#
+# This script verifies the downloaded EndlessOS Bundle and checks its
+# integrity, extracts the bundle into a temporary file and finally moves
+# it to its corresponding installation directory.
+#
+# Usage:
+#
+# $ ./20-external.sh <app_id> 
+#
+# Parameters:
+# <app_id>: ID of the application to install.
+#
+# Returns 0 on success.
+
+. ${BASH_SOURCE[0]%/*}/../../utils.sh
+
+print_header "${BASH_SOURCE[0]}"
+check_args_minimum_number "${#}" 1 "<app_id>"
+APP_ID=$1
+
+parse_ini "${EAM_TMP}/${APP_ID}/.info" "External"
+
+if [ -z "$url" ]; then
+    exit 0
+fi
+
+output_dir="${EAM_TMP}/${APP_ID}/external"
+index=0
+
+mkdir -p ${output_dir}
+
+while [ -n "${url[${index}]}" ] ; do
+    external_url=${url[${index}]}
+    external_filename=${output_dir}/${filename[${index}]}
+    external_sha256sum=${sha256sum[${index}]}
+
+    wget -q ${external_url} -O ${external_filename}
+    echo "${external_sha256sum} ${external_filename}" | sha256sum --quiet --status --check
+    ((++index))
+done
+

--- a/scripts/install/run/30-install.sh
+++ b/scripts/install/run/30-install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# Copyright 2014 Endless Mobile, Inc.
+#
+# This script verifies the downloaded EndlessOS Bundle and checks its
+# integrity, extracts the bundle into a temporary file and finally moves
+# it to its corresponding installation directory.
+#
+# Usage:
+#
+# $ ./30-install.sh <app_id>
+#
+# Parameters:
+# <app_id>: ID of the application to install.
+#
+# Returns 0 on success.
+
+. ${BASH_SOURCE[0]%/*}/../../utils.sh
+
+print_header "${BASH_SOURCE[0]}"
+check_args_minimum_number "${#}" 1 "<app_id>"
+APP_ID=$1
+
+mv "${EAM_TMP}/${APP_ID}" "${EAM_PREFIX}"

--- a/scripts/install/run/40-symlinks.sh
+++ b/scripts/install/run/40-symlinks.sh
@@ -5,7 +5,7 @@
 # This script creates symbolic links, on common OS
 # directories, for the application metadata files.
 #
-# Usage: ./02-symlinks.sh <app_id> ...
+# Usage: ./40-symlinks.sh <app_id> ...
 #
 # Parameters:
 # <app_id>: ID of the application to install.

--- a/scripts/install/run/50-desktop-updates.sh
+++ b/scripts/install/run/50-desktop-updates.sh
@@ -7,7 +7,7 @@
 # updates the icon theme cache and the cache database of
 # the MIME types handled by the .desktop files.
 #
-# Usage: ./03-desktop-updates.sh ...
+# Usage: ./50-desktop-updates.sh ...
 
 . ${BASH_SOURCE[0]%/*}/../../utils.sh
 

--- a/scripts/install/run/60-cleanup.sh
+++ b/scripts/install/run/60-cleanup.sh
@@ -5,7 +5,7 @@
 # This script cleans temporary files created
 # during an application installation.
 #
-# Usage: ./04-clean.sh <app_id> <bundle_path> ...
+# Usage: ./60-clean.sh <app_id> <bundle_path> ...
 #
 # Parameters:
 # <app_id>: ID of the application to install.

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -212,3 +212,24 @@ delete_dir ()
 
     rm --recursive --force "${dir}"
 }
+
+# .info
+#------
+# Parses the a ini-like file
+parse_ini ()
+{
+    if [ "$#" -ne 2 ]; then
+        exit_error "parse_ini: incorrect number of arguments"
+    fi
+
+    config_file=$1
+    section=$2
+
+    eval `sed -e 's/[[:space:]]*\=[[:space:]]*/=/g' \
+      -e 's/;.*$//' \
+      -e 's/[[:space:]]*$//' \
+      -e 's/^[[:space:]]*//' \
+      -e "s/^\(.*\)=\([^\"']*\)$/\1=\"\2\"/" \
+     < ${config_file} \
+      | sed -n -e "/^\[${section}\]/,/^\s*\[/{/^[^;].*\=.*/p;}"`
+}


### PR DESCRIPTION
Handle external components

The .info file in a bundle can specify one or more external files to be
downloaded, in a [External] section.

It requires three values:
- url = `url to download`
- filename = `output filename for the downloaded content`
- sha256sum = `SHA256 checksum for the downloaded content`

It is possible to define more than one file to download. In this case,
each of the parameters will be indexed, starting in 0: url0],
filename[0], sha256sum[0], url[1], filename[1], sha256sum[1], ...

All the downloaded content will be stored at
${EAM_TMP}/${APP_ID}/external

[endlessm/eos-shell#2799]
