### PR TITLE
Handle external components

### DIFF
--- a/scripts/install/run/10-extract.sh
+++ b/scripts/install/run/10-extract.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #
-# $ ./01-extract.sh <app_id> <bundle_file_path> ...
+# $ ./10-extract.sh <app_id> <bundle_file_path> ...
 #
 # Parameters:
 # <app_id>: ID of the application to install.
@@ -33,4 +33,3 @@ BUNDLE=$2
 
 verify_downloaded_file "${BUNDLE}" "${APP_ID}.sha256" "${APP_ID}.asc"
 extract_file_to_dir "${BUNDLE}" "${EAM_TMP}"
-mv "${EAM_TMP}/${APP_ID}" "${EAM_PREFIX}"

--- a/scripts/install/run/20-external.sh
+++ b/scripts/install/run/20-external.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+
+# Copyright 2014 Endless Mobile, Inc.
+#
+# This script verifies the downloaded EndlessOS Bundle and checks its
+# integrity, extracts the bundle into a temporary file and finally moves
+# it to its corresponding installation directory.
+#
+# Usage:
+#
+# $ ./20-external.sh <app_id> 
+#
+# Parameters:
+# <app_id>: ID of the application to install.
+#
+# Returns 0 on success.
+
+. ${BASH_SOURCE[0]%/*}/../../utils.sh
+
+print_header "${BASH_SOURCE[0]}"
+check_args_minimum_number "${#}" 1 "<app_id>"
+APP_ID=$1
+INFO="${EAM_TMP}/${APP_ID}/.info"
+
+output_dir="${EAM_TMP}/${APP_ID}/external"
+mkdir -p ${output_dir}
+
+parse_ini_get_sections ${INFO}
+
+for section in "${sections[@]}" ; do
+    if  [[ $section != External* ]] ; then
+        continue
+    fi
+
+    parse_ini_section ${INFO} "${section}"
+    output_file=${output_dir}/${filename}
+
+    wget -q ${url} -O ${output_file}
+    echo "${sha256sum} ${output_file}" | sha256sum --quiet --status --check
+done

--- a/scripts/install/run/30-install.sh
+++ b/scripts/install/run/30-install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# Copyright 2014 Endless Mobile, Inc.
+#
+# This script verifies the downloaded EndlessOS Bundle and checks its
+# integrity, extracts the bundle into a temporary file and finally moves
+# it to its corresponding installation directory.
+#
+# Usage:
+#
+# $ ./30-install.sh <app_id>
+#
+# Parameters:
+# <app_id>: ID of the application to install.
+#
+# Returns 0 on success.
+
+. ${BASH_SOURCE[0]%/*}/../../utils.sh
+
+print_header "${BASH_SOURCE[0]}"
+check_args_minimum_number "${#}" 1 "<app_id>"
+APP_ID=$1
+
+mv "${EAM_TMP}/${APP_ID}" "${EAM_PREFIX}"

--- a/scripts/install/run/40-symlinks.sh
+++ b/scripts/install/run/40-symlinks.sh
@@ -5,7 +5,7 @@
 # This script creates symbolic links, on common OS
 # directories, for the application metadata files.
 #
-# Usage: ./02-symlinks.sh <app_id> ...
+# Usage: ./40-symlinks.sh <app_id> ...
 #
 # Parameters:
 # <app_id>: ID of the application to install.

--- a/scripts/install/run/50-desktop-updates.sh
+++ b/scripts/install/run/50-desktop-updates.sh
@@ -7,7 +7,7 @@
 # updates the icon theme cache and the cache database of
 # the MIME types handled by the .desktop files.
 #
-# Usage: ./03-desktop-updates.sh ...
+# Usage: ./50-desktop-updates.sh ...
 
 . ${BASH_SOURCE[0]%/*}/../../utils.sh
 

--- a/scripts/install/run/60-cleanup.sh
+++ b/scripts/install/run/60-cleanup.sh
@@ -5,7 +5,7 @@
 # This script cleans temporary files created
 # during an application installation.
 #
-# Usage: ./04-clean.sh <app_id> <bundle_path> ...
+# Usage: ./60-clean.sh <app_id> <bundle_path> ...
 #
 # Parameters:
 # <app_id>: ID of the application to install.

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -212,3 +212,36 @@ delete_dir ()
 
     rm --recursive --force "${dir}"
 }
+
+# .info
+#------
+# Get an array with all the sections available in a ini-like file
+parse_ini_get_sections ()
+{
+    if [ "$#" -ne 1 ]; then
+        exit_error "parse_ini_get_sections: incorrect number of arguments"
+    fi
+
+    config_file=$1
+
+    eval sections=(`grep "^\[" ${config_file} | tr '\[' '"' | tr '\]' '"' `)
+}
+
+# Parses the section from a ini-like file
+parse_ini_section ()
+{
+    if [ "$#" -ne 2 ]; then
+        exit_error "parse_ini_section: incorrect number of arguments"
+    fi
+
+    config_file=$1
+    section=$2
+
+    eval `sed -e 's/[[:space:]]*\=[[:space:]]*/=/g' \
+      -e 's/;.*$//' \
+      -e 's/[[:space:]]*$//' \
+      -e 's/^[[:space:]]*//' \
+      -e "s/^\(.*\)=\([^\"']*\)$/\1=\"\2\"/" \
+     < ${config_file} \
+      | sed -n -e "/^\[${section}\]/,/^\s*\[/{/^[^;].*\=.*/p;}"`
+}


### PR DESCRIPTION
The .info file in a bundle can specify one or more external files to be
downloaded, in a [External] section.

It requires three values:
- url = `url to download`
- filename = `output filename for the downloaded content`
- sha256sum = `SHA256 checksum for the downloaded content`

It is possible to define more than one file to download. In this case,
we need to define several external sections, giving to each them an
identifier:

```
[External <id1>]
url=...
filename=...
sha256sum=...

[External <id2>]
url=...
filename=...
sha256sum=...
```

All the downloaded content will be stored at
${EAM_TMP}/${APP_ID}/external

[endlessm/eos-shell#2799]
