### PR TITLE
Run custom installer

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -7,11 +7,12 @@ common_scripts = \
 
 install_scripts = \
 	install/run/10-extract.sh \
-	install/run/20-external.sh\
-	install/run/30-install.sh \
-	install/run/40-symlinks.sh \
-	install/run/50-desktop-updates.sh \
-	install/run/60-cleanup.sh \
+	install/run/20-external.sh \
+	install/run/30-custom-installer.sh \
+	install/run/40-install.sh \
+	install/run/50-symlinks.sh \
+	install/run/60-desktop-updates.sh \
+	install/run/70-cleanup.sh \
 	install/rollback/01-delete-symlinks.sh \
 	install/rollback/02-cleanup.sh \
 	install/rollback/03-desktop-updates.sh \

--- a/scripts/install/run/30-custom-installer.sh
+++ b/scripts/install/run/30-custom-installer.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+# Copyright 2014 Endless Mobile, Inc.
+#
+# This script runs the custom installer provided by the bundle.
+#
+# Usage:
+#
+# $ ./30-custom-installer.sh <app_id>
+#
+# Parameters:
+# <app_id>: ID of the application to install.
+#
+# Returns 0 on success.
+
+. ${BASH_SOURCE[0]%/*}/../../utils.sh
+
+print_header "${BASH_SOURCE[0]}"
+check_args_minimum_number "${#}" 1 "<app_id>"
+APP_ID=$1
+WORKPATH=${EAM_TMP}/${APP_ID}
+
+if [ -x ${WORKPATH}/.script.install ] ; then
+    cd ${WORKPATH} && ${WORKPATH}/.script.install ${APP_ID} ${WORKPATH}
+fi

--- a/scripts/install/run/40-install.sh
+++ b/scripts/install/run/40-install.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #
-# $ ./30-install.sh <app_id>
+# $ ./40-install.sh <app_id>
 #
 # Parameters:
 # <app_id>: ID of the application to install.

--- a/scripts/install/run/50-symlinks.sh
+++ b/scripts/install/run/50-symlinks.sh
@@ -5,7 +5,7 @@
 # This script creates symbolic links, on common OS
 # directories, for the application metadata files.
 #
-# Usage: ./40-symlinks.sh <app_id> ...
+# Usage: ./50-symlinks.sh <app_id> ...
 #
 # Parameters:
 # <app_id>: ID of the application to install.

--- a/scripts/install/run/60-desktop-updates.sh
+++ b/scripts/install/run/60-desktop-updates.sh
@@ -7,7 +7,7 @@
 # updates the icon theme cache and the cache database of
 # the MIME types handled by the .desktop files.
 #
-# Usage: ./50-desktop-updates.sh ...
+# Usage: ./60-desktop-updates.sh ...
 
 . ${BASH_SOURCE[0]%/*}/../../utils.sh
 

--- a/scripts/install/run/70-cleanup.sh
+++ b/scripts/install/run/70-cleanup.sh
@@ -5,7 +5,7 @@
 # This script cleans temporary files created
 # during an application installation.
 #
-# Usage: ./60-clean.sh <app_id> <bundle_path> ...
+# Usage: ./70-clean.sh <app_id> <bundle_path> ...
 #
 # Parameters:
 # <app_id>: ID of the application to install.


### PR DESCRIPTION
If the bundle provides a custom installer (a `.script.install` file) it
will be executed after the bundle is uncompressed, and the external
files are downloaded (if any).

[endlessm/eos-shell#2800]
