### PR TITLE
Rename app manager service

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,14 +3,14 @@ RESOURCE_FILES = \
 	$(NULL)
 
 dbusservicedir       = $(datadir)/dbus-1/system-services
-dbusservice_in_files = com.Endless.AppManager.service.in
+dbusservice_in_files = com.endlessm.AppManager.service.in
 dbusservice_DATA     = $(dbusservice_in_files:.service.in=.service)
 
 $(dbusservice_DATA): $(dbusservice_in_files) Makefile
 	@sed -e "s|\@bindir\@|$(bindir)|" -e "s|\@EAM_USER\@|$(EAM_USER)|" $< > $@
 
 dbusconfdir = $(sysconfdir)/dbus-1/system.d
-dbusconf_in_files = com.Endless.AppManager.conf.in
+dbusconf_in_files = com.endlessm.AppManager.conf.in
 dbusconf_DATA = $(dbusconf_in_files:.conf.in=.conf)
 
 systemdservice_in_files = eos-app-manager.service.in

--- a/data/com.endlessm.AppManager.conf.in
+++ b/data/com.endlessm.AppManager.conf.in
@@ -7,13 +7,13 @@
 
   <!-- Only EAM_USER can own the AppManager service -->
   <policy user="@EAM_USER@">
-    <allow own="com.Endless.AppManager"/>
+    <allow own="com.endlessm.AppManager"/>
   </policy>
 
   <!-- Allow anyone to invoke methods on the AppManager server -->
   <policy context="default">
-    <allow send_destination="com.Endless.AppManager"/>
-    <allow receive_sender="com.Endless.AppManager"/>
+    <allow send_destination="com.endlessm.AppManager"/>
+    <allow receive_sender="com.endlessm.AppManager"/>
   </policy>
 
 </busconfig>

--- a/data/com.endlessm.AppManager.service.in
+++ b/data/com.endlessm.AppManager.service.in
@@ -1,4 +1,4 @@
 [D-BUS Service]
-Name=com.Endless.AppManager
+Name=com.endlessm.AppManager
 Exec=@bindir@/eam
 User=@EAM_USER@

--- a/data/eam-dbus-interface.xml
+++ b/data/eam-dbus-interface.xml
@@ -5,12 +5,12 @@
 
 <node>
   <!--
-      com.Endless.AppManager:
+      com.endlessm.AppManager:
       @short_description: The EOS Application Manager service
 
       This is the interface you use to talk with the EOS Application Manager.
   -->
-  <interface name="com.Endless.AppManager">
+  <interface name="com.endlessm.AppManager">
 
     <!--
 	AvailableUpdates as read-only:

--- a/data/eam.gresource.xml
+++ b/data/eam.gresource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-  <gresource prefix="/com/Endless/AppManager">
+  <gresource prefix="/com/endlessm/AppManager">
     <file preprocess="xml-stripblanks" compressed="true">eam-dbus-interface.xml</file>
   </gresource>
 </gresources>

--- a/data/eos-app-manager.service.in
+++ b/data/eos-app-manager.service.in
@@ -4,5 +4,5 @@ Documentation=man:eam(8)
 
 [Service]
 Type=dbus
-BusName=com.Endless.AppManager
+BusName=com.endlessm.AppManager
 ExecStart=@bindir@/eam

--- a/src/eam-dbus-server.c
+++ b/src/eam-dbus-server.c
@@ -234,7 +234,7 @@ eam_dbus_server_new (EamPkgdb *db)
  * eam_dbus_server_run:
  * @server: a #EamDbusServer.
  *
- * Acquire the DBus name "com.Endlesss.AppManager" and launch de
+ * Acquire the DBus name "com.endlesssm.AppManager" and launch de
  * AppManager service.
  *
  * Returns: %TRUE if the server is launched. Otherwise %FALSE;
@@ -256,7 +256,7 @@ eam_dbus_server_run (EamDbusServer *server)
     return FALSE;
   }
 
-  priv->busowner = g_bus_own_name (G_BUS_TYPE_SYSTEM, "com.Endless.AppManager",
+  priv->busowner = g_bus_own_name (G_BUS_TYPE_SYSTEM, "com.endlessm.AppManager",
     G_BUS_NAME_OWNER_FLAGS_REPLACE | G_BUS_NAME_OWNER_FLAGS_ALLOW_REPLACEMENT,
     on_bus_acquired, on_name_acquired, on_name_lost,
     g_object_ref (server), (GDestroyNotify) g_object_unref);

--- a/src/eam-service.c
+++ b/src/eam-service.c
@@ -320,12 +320,12 @@ do_signal:
     g_variant_builder_add (&changed, "{sv}", "AvailableUpdates",
       build_available_updates_variant (service));
 
-    GVariant *params = g_variant_new ("(sa{sv}as)", "com.Endless.AppManager",
+    GVariant *params = g_variant_new ("(sa{sv}as)", "com.endlessm.AppManager",
       &changed, &invalidated);
 
     GError *error = NULL;
     g_dbus_connection_emit_signal (priv->connection, NULL,
-      "/com/Endless/AppManager", "org.freedesktop.DBus.Properties",
+      "/com/endlessm/AppManager", "org.freedesktop.DBus.Properties",
       "PropertiesChanged", params, &error);
 
     if (error) {
@@ -346,7 +346,7 @@ avails_changed_cb (EamService *service, gpointer data)
 
   GError *error = NULL;
   g_dbus_connection_emit_signal (priv->connection, NULL,
-    "/com/Endless/AppManager", "com.Endless.AppManager",
+    "/com/endlessm/AppManager", "com.endlessm.AppManager",
     "AvailableApplicationsChanged", build_avail_pkg_list_variant (service),
     &error);
 
@@ -1029,7 +1029,7 @@ handle_method_call (GDBusConnection *connection, const char *sender,
   EamService *service = EAM_SERVICE (data);
   int method_i;
 
-  if (g_strcmp0 (interface, "com.Endless.AppManager"))
+  if (g_strcmp0 (interface, "com.endlessm.AppManager"))
     return;
 
   for (method_i = 0; method_i < G_N_ELEMENTS (auth_action); method_i++)
@@ -1048,7 +1048,7 @@ handle_get_property (GDBusConnection *connection, const gchar *sender,
 
   eam_service_reset_timer (service);
 
-  if (g_strcmp0 (interface, "com.Endless.AppManager"))
+  if (g_strcmp0 (interface, "com.endlessm.AppManager"))
     return NULL;
 
   if (!g_strcmp0 (name, "AvailableUpdates"))
@@ -1069,7 +1069,7 @@ static GDBusNodeInfo*
 load_introspection (GError **error)
 {
   GDBusNodeInfo *info = NULL;
-  GBytes *data = g_resources_lookup_data ("/com/Endless/AppManager/eam-dbus-interface.xml",
+  GBytes *data = g_resources_lookup_data ("/com/endlessm/AppManager/eam-dbus-interface.xml",
     G_RESOURCE_LOOKUP_FLAGS_NONE, error);
 
   if (!data)
@@ -1107,7 +1107,7 @@ eam_service_dbus_register (EamService *service, GDBusConnection *connection)
   }
 
   priv->registration_id = g_dbus_connection_register_object (connection,
-    "/com/Endless/AppManager", introspection->interfaces[0], &interface_vtable,
+    "/com/endlessm/AppManager", introspection->interfaces[0], &interface_vtable,
     service, NULL, &error);
 
   if (!priv->registration_id) {

--- a/tools/dbus-client.sh
+++ b/tools/dbus-client.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 GDBUS=`which gdbus`
-PARAMS="--system --dest com.Endless.AppManager --object-path /com/Endless/AppManager"
+PARAMS="--system --dest com.endlessm.AppManager --object-path /com/endlessm/AppManager"
 
 call() {
     method=$1; shift
-    ${GDBUS} call ${PARAMS} --method com.Endless.AppManager.${method} $*
+    ${GDBUS} call ${PARAMS} --method com.endlessm.AppManager.${method} $*
 }
 
 introspect() {


### PR DESCRIPTION
From com.Endless.AppManager to com.endlessm.AppManager,
to match the expectations of the app store,
and for consistency with other Endless services.

[endlessm/eos-shell#2860]
