### PR TITLE
Create app-manager user

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+eos-app-manager (0.1-2) eos; urgency=medium
+
+  * debian/postinst:
+    Create app-manager user
+    [endlessm/eos-shell#2794]
+
+ -- Juan A. Suarez Romero <jasuarez@igalia.com>  Wed, 02 Jul 2014 12:39:00 +0200
+
 eos-app-manager (0.1-1) eos; urgency=medium
 
   * Initial release.

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -eu
++app-manager:*:116:65534:Endless App Manager:/var/endless:/usr/sbin/nologin
+
+# creating app-manager user if it isn't already there
+if ! getent passwd app-manager >/dev/null; then
+        adduser --system --force-badname --quiet \
+            --no-create-home \
+            --home /var/endless \
+            --shell /usr/sbin/nologin \
+            app-manager
+fi
+
+#DEBHELPER#
+
+exit 0
+


### PR DESCRIPTION
Required to run AppManager.

[endlessm/eos-shell#2794]
