### PR TITLE
pkgdb: ignore bin as a appid

### DIFF
--- a/src/eam-pkgdb.c
+++ b/src/eam-pkgdb.c
@@ -126,17 +126,21 @@ static gboolean
 appid_is_legal (const char *appid)
 {
   static const char alsoallowed[] = "-+.";
-  int c;
+  static const char *reserveddirs[] = { "bin", "share" };
 
   if (!appid || appid[0] == '\0')
     return FALSE;
 
-  if (g_strcmp0 (appid, "share") == 0)
-    return FALSE;
+  guint i;
+  for (i = 0; i < G_N_ELEMENTS(reserveddirs); i++) {
+    if (g_strcmp0(appid, reserveddirs[i]) == 0)
+      return FALSE;
+  }
 
   if (!g_ascii_isalnum (appid[0]))
     return FALSE; /* must start with an alphanumeric character */
 
+  int c;
   while ((c = *appid++) != '\0')
     if (!g_ascii_isalnum (c) && !strchr (alsoallowed, c))
       break;


### PR DESCRIPTION
The bin/ directory is now part of /endless structure, hence we
must ignore it too when traversing the directory looking for
the installed bundles.

[endlessm/eos-shell#2881]
