### PR TITLE
app-manager group postinst handling

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -12,6 +12,13 @@ if ! getent passwd app-manager >/dev/null; then
             app-manager
 fi
 
+# create /var/endless or update ownership existing directory
+if [ -d /var/endless ]; then
+	chown -R app-manager:app-manager /var/endless
+else
+	install -d -m0755 -o app-manager -g app-manager /var/endless
+fi
+
 #DEBHELPER#
 
 exit 0


### PR DESCRIPTION
Adds the app-manager group if necessary and ensures that users getting eos-app-manager via apt-get have proper ownership of /var/endless.

[endlessm/eos-shell#2915]
