### PR TITLE
data: Make /var/endless group app-manager

### DIFF
--- a/data/eos-app-manager.conf
+++ b/data/eos-app-manager.conf
@@ -1,3 +1,3 @@
 # Type Path    Mode UID  GID  Age Argument
-d /var/endless 0755 app-manager root -
+d /var/endless 0755 app-manager app-manager -
 L /endless     -    -           -    - /var/endless


### PR DESCRIPTION
With the app-manager user in its own app-manager group, it makes sense
to have /var/endless and all files under it owned by
app-manager:app-manager.

[endlessm/eos-shell#2915]
