### PR TITLE
utils: add --no-default-keyring to gpg invocation

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -60,7 +60,7 @@ verify_downloaded_file ()
     cd $DIR
 
     sha256sum --quiet --status --check "${sha256file}"
-    gpg --keyring="${EAM_GPGKEYRING}" --quiet --verify "${gpgfile}" "${file}"
+    gpg --no-default-keyring --keyring="${EAM_GPGKEYRING}" --quiet --verify "${gpgfile}" "${file}"
 }
 
 # Deletes the downloaded file, its sha256file and GPG signature.


### PR DESCRIPTION
We don't want gpg to create a default keyring, and we want to check keys
exclusively from our own.

[endlessm/eos-shell#2916]
