### PR TITLE
Use download directory as temporal one

### DIFF
--- a/src/eam-install.c
+++ b/src/eam-install.c
@@ -326,7 +326,7 @@ run_scripts (EamInstall *self, const gchar *scriptdir,
 
   /* prefix environment */
   g_setenv ("EAM_PREFIX", eam_config_appdir (), FALSE);
-  g_setenv ("EAM_TMP", g_get_tmp_dir (), FALSE);
+  g_setenv ("EAM_TMP", eam_config_dldir (), FALSE);
   g_setenv ("EAM_GPGKEYRING", eam_config_gpgkeyring (), FALSE);
 
   EamSpawner *spawner = eam_spawner_new (dir, (const gchar * const *) params);

--- a/src/eam-uninstall.c
+++ b/src/eam-uninstall.c
@@ -72,7 +72,7 @@ eam_uninstall_run_async (EamTransaction *trans, GCancellable *cancellable,
 
   char *dir = g_build_filename (eam_config_scriptdir (), "uninstall", NULL);
   g_setenv ("EAM_PREFIX", eam_config_appdir (), FALSE);
-  g_setenv ("EAM_TMP", g_get_tmp_dir (), FALSE);
+  g_setenv ("EAM_TMP", eam_config_dldir (), FALSE);
 
   GStrv params = g_new0 (gchar *, 2);
   params[0] = g_strdup (priv->appid);


### PR DESCRIPTION
We were using the systems temporal directory, but that directory,
usually /tmp is not always big enough for the app-manager operation.

This patch changes the system's temporal directory for the one used
for downloading the bundles.

[endlessm/eos-shell#3056]
