### PR TITLE
scripts: use correct relative path to utils.sh

### DIFF
--- a/scripts/uninstall/00-directories.sh
+++ b/scripts/uninstall/00-directories.sh
@@ -7,7 +7,7 @@
 #
 # Usage: ./00-directories.sh ...
 
-. ${BASH_SOURCE[0]%/*}/../../utils.sh
+. ${BASH_SOURCE[0]%/*}/../utils.sh
 
 print_header "${BASH_SOURCE[0]}"
 create_os_directories


### PR DESCRIPTION
We were moving up one directory too many...

[endlessm/eos-shell#3073]
