### PR TITLE
Set app architecture from debian architecture

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,3 +10,6 @@
 override_dh_autoreconf:
 	intltoolize --force --copy
 	dh_autoreconf
+
+override_dh_auto_configure:
+	dh_auto_configure -- --with-eos-arch=$(DEB_HOST_ARCH)


### PR DESCRIPTION
Rather than letting the configure script guess, pass in the architecture
to use from DEB_HOST_ARCH.

[endlessm/eos-shell#3161]
