### PR TITLE
Notify available apps changed after (un)installing an app

### DIFF
--- a/src/eam-service.c
+++ b/src/eam-service.c
@@ -619,6 +619,10 @@ reload_pkgdb_after_transaction_cb (GObject *source, GAsyncResult *res, gpointer 
   GVariant *value = g_variant_new ("(b)", TRUE);
   g_dbus_method_invocation_return_value (invocation, value);
 
+  /* Let's notify the available apps list has changed, as an installed app is
+     not available anymore, and uninstalled app becomes available */
+  avails_changed_cb (service, NULL);
+
 out:
   eam_service_clear_transaction (service);
 }


### PR DESCRIPTION
The list of available applications are formed by those applications that are in
the server but not installed in our system.

So if we install an application, it becomes unavailable. And the opposite, if
we uninstall an application now it becomes available.

Thus, when installing or uninstalling an application we need to notify that the
list of available applications has changed.

[endlessm/eos-shell#3158]
