### PR TITLE
Shell/3781

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,6 @@ Homepage: http://www.endlessm.com
 Package: eos-app-manager
 Section: non-free/admin
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, gnupg, xdelta3-dir-patcher, wget
+Depends: ${shlibs:Depends}, ${misc:Depends}, gpgv, xdelta3-dir-patcher, wget
 Description: Endless Application Manager
  DBus service for installing, removing and updagrading Endless applications.


### PR DESCRIPTION
Given [endlessm/eos-shell#3505] the scripts now use gpgv rather
than gnupg. This patch updates debian/control file to reflect
this dependency change.

[endlessm/eos-shell#3781]
