### PR TITLE
scripts: use --ignore-euid for xdelta3-dir-patcher

### DIFF
--- a/scripts/update/xdelta/20-apply-xdelta.sh
+++ b/scripts/update/xdelta/20-apply-xdelta.sh
@@ -25,4 +25,4 @@ APP_ID=$1
 BUNDLE=$2
 
 delete_dir "${EAM_TMP}/${APP_ID}" && mkdir "${EAM_TMP}/${APP_ID}"
-xdelta3-dir-patcher apply "${EAM_PREFIX}/${APP_ID}" "${BUNDLE}" "${EAM_TMP}/${APP_ID}"
+xdelta3-dir-patcher apply --ignore-euid "${EAM_PREFIX}/${APP_ID}" "${BUNDLE}" "${EAM_TMP}/${APP_ID}"


### PR DESCRIPTION
Since the change of application-manager to run as non-root, the
xdelta3-dir-patcher stopped to work, since it, by default, expects to be
executed as root in order to keep the same file permissions.

This patch fix this issue by setting the parameter --ignore-euid , which seems
enough since the whole /endless filesystem is manager by the app-manager user.

[endlessm/eos-shell#3899]
