### PR TITLE
AppUpdater: Pass the offset dir in the xdelta from were to use the diffs

### DIFF
--- a/scripts/update/xdelta/20-apply-xdelta.sh
+++ b/scripts/update/xdelta/20-apply-xdelta.sh
@@ -25,4 +25,4 @@ APP_ID=$1
 BUNDLE=$2
 
 delete_dir "${EAM_TMP}/${APP_ID}" && mkdir "${EAM_TMP}/${APP_ID}"
-xdelta3-dir-patcher apply --ignore-euid "${EAM_PREFIX}/${APP_ID}" "${BUNDLE}" "${EAM_TMP}/${APP_ID}"
+xdelta3-dir-patcher apply --ignore-euid -d "${APP_ID}" "${EAM_PREFIX}/${APP_ID}" "${BUNDLE}" "${EAM_TMP}/${APP_ID}"


### PR DESCRIPTION
XDeltas contain the base appid directory so without this change, the
directories are not properly processed since the target doesn't contain
the same layout. This change also requires xdelta3-dir-patcher changes.

[endlessm/eos-shell#2654]
