### PR TITLE
eam-fs-sanity: fix permissions for application files when needed

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,6 +27,7 @@ source_c = \
 	eam-list-avail.c \
 	eam-log.c \
 	eam-error.c \
+	eam-utils.c \
 	$(NULL)
 
 source_h = \
@@ -51,6 +52,7 @@ source_h = \
 	eam-list-avail.h \
 	eam-log.h \
 	eam-error.h \
+	eam-utils.h \
 	$(NULL)
 
 eam_built_sources = \

--- a/src/eam-pkgdb.c
+++ b/src/eam-pkgdb.c
@@ -4,9 +4,8 @@
 
 #include <glib/gi18n.h>
 
-#include <string.h>
-
 #include "eam-pkgdb.h"
+#include "eam-utils.h"
 #include "eam-version.h"
 
 typedef struct _EamPkgdbPrivate	EamPkgdbPrivate;
@@ -120,35 +119,6 @@ eam_pkgdb_new_with_appdir (const gchar *appdir)
   return g_object_new (EAM_TYPE_PKGDB, "appdir", appdir, NULL);
 }
 
-static gboolean
-appid_is_legal (const char *appid)
-{
-  static const char alsoallowed[] = "-+.";
-  static const char *reserveddirs[] = { "bin", "share" };
-
-  if (!appid || appid[0] == '\0')
-    return FALSE;
-
-  guint i;
-  for (i = 0; i < G_N_ELEMENTS(reserveddirs); i++) {
-    if (g_strcmp0(appid, reserveddirs[i]) == 0)
-      return FALSE;
-  }
-
-  if (!g_ascii_isalnum (appid[0]))
-    return FALSE; /* must start with an alphanumeric character */
-
-  int c;
-  while ((c = *appid++) != '\0')
-    if (!g_ascii_isalnum (c) && !strchr (alsoallowed, c))
-      break;
-
-  if (!c)
-    return TRUE;
-
-  return FALSE;
-}
-
 /**
  * eam_pkgdb_add:
  * @pkgdb: a #EamPkgdb
@@ -166,7 +136,7 @@ eam_pkgdb_add (EamPkgdb *pkgdb, const gchar *appid, EamPkg *pkg)
   g_return_val_if_fail (appid != NULL, FALSE);
   g_return_val_if_fail (pkg, FALSE);
 
-  if (!appid_is_legal (appid))
+  if (!eam_utils_appid_is_legal (appid))
     return FALSE;
 
   EamPkgdbPrivate *priv = eam_pkgdb_get_instance_private (pkgdb);
@@ -200,7 +170,7 @@ eam_pkgdb_replace (EamPkgdb *pkgdb, EamPkg *pkg)
   g_return_val_if_fail (pkg, FALSE);
 
   const gchar *appid = eam_pkg_get_id (pkg);
-  if (!appid_is_legal (appid))
+  if (!eam_utils_appid_is_legal (appid))
     return FALSE;
 
   EamPkgdbPrivate *priv = eam_pkgdb_get_instance_private (pkgdb);
@@ -420,7 +390,7 @@ eam_pkgdb_load (EamPkgdb *pkgdb, GError **error)
 
   const gchar *appid;
   while ((appid = g_dir_read_name (dir))) {
-    if (!appid_is_legal (appid))
+    if (!eam_utils_appid_is_legal (appid))
       continue;
 
     gchar *info = g_build_path (G_DIR_SEPARATOR_S, priv->appdir, appid, ".info", NULL);

--- a/src/eam-utils.c
+++ b/src/eam-utils.c
@@ -1,0 +1,35 @@
+/* Copyright 2014 Endless Mobile, Inc. */
+#include "config.h"
+
+#include <string.h>
+
+#include "eam-utils.h"
+
+gboolean
+eam_utils_appid_is_legal (const char *appid)
+{
+  static const char alsoallowed[] = "-+.";
+  static const char *reserveddirs[] = { "bin", "share" };
+
+  if (!appid || appid[0] == '\0')
+    return FALSE;
+
+  guint i;
+  for (i = 0; i < G_N_ELEMENTS(reserveddirs); i++) {
+    if (g_strcmp0(appid, reserveddirs[i]) == 0)
+      return FALSE;
+  }
+
+  if (!g_ascii_isalnum (appid[0]))
+    return FALSE; /* must start with an alphanumeric character */
+
+  int c;
+  while ((c = *appid++) != '\0')
+    if (!g_ascii_isalnum (c) && !strchr (alsoallowed, c))
+      break;
+
+  if (!c)
+    return TRUE;
+
+  return FALSE;
+}

--- a/src/eam-utils.h
+++ b/src/eam-utils.h
@@ -1,0 +1,14 @@
+/* Copyright 2014 Endless Mobile, Inc. */
+
+#ifndef EAM_UTILS_H
+#define EAM_UTILS_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+gboolean eam_utils_appid_is_legal       (const char *appid);
+
+G_END_DECLS
+
+#endif


### PR DESCRIPTION
We've seen cases where an installed bundle in /endless would not have
the right permissions set for its directory and its files (e.g. ri-li),
making it impossible for the user to use that application, as well as
for the app store to show it as an "installed application", since access
to the relevant files (e.g. binaries, .desktop files) would not be possible.

This patch performs a quick check when calling eam_fs_sanity_check()
that would cause EAM to try to restore permissions for the files of a
bundle to a more sane state when the app directory is not readable by
"others", which is needed for the app store to see them.

It's not a perfect "check and fix" algorithm, but it's quick enough not
to add a significant extra overhead on startup, and probably sane enough
as it considers previously present permission for the files/dirs it has
to fix, adding only the 'r-x' ones on top if, and only if, those
permissions are set for the owner too.

[endlessm/eos-shell#4250]
