### PR TITLE
App Manager: Added default deltaupdates value to the config file

### DIFF
--- a/data/eam-default.cfg.in
+++ b/data/eam-default.cfg.in
@@ -6,3 +6,4 @@ protocolversion = v1
 scriptdir = @pkglibexecdir@
 gpgkeyring = @pkgdatadir@/eos-keyring.gpg
 timeout = 300
+deltaupdates = false


### PR DESCRIPTION
Trying to remember the name of this magic key was difficult so this
should make debugging, testing, and QA much easier.

[endlessm/eos-shell#4441]
