### PR TITLE
Return NULL if load_from_keyfile fails

### DIFF
--- a/src/eam-pkg.c
+++ b/src/eam-pkg.c
@@ -225,6 +225,9 @@ eam_pkg_new_from_filename (const gchar *filename, GError **error)
 
   g_key_file_unref (keyfile);
 
+  if (pkg == NULL)
+    return NULL;
+
   /* check if the metadata is on a read-only storage, and toggle the
    * secondary-storage flag regardless of what's in the metadata
    */


### PR DESCRIPTION
eam_pkg_new_from_filename() was missing a check to see if
eam_pkg_load_from_keyfile() failed. If it failed, then new_from_filename
needs to return NULL. The error information is already in *error.

[endlessm/eos-shell#4584]
