### PR TITLE
Remove ekn manifest symlinking

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -48,8 +48,6 @@ APP_DBUS_SERVICES_SUBDIR="share/dbus-1/services"
 APP_HELP_SUBDIR="share/help"
 # Application knowledge app data.
 APP_EKN_DATA_SUBDIR="share/ekn/data"
-# Application knowledge app manifest.
-APP_EKN_MANIFEST_SUBDIR="share/ekn/manifest"
 # Application shell search provider directory.
 APP_SHELL_SEARCH_SUBDIR="share/gnome-shell/search-providers"
 # Application KDE help subdirectory.
@@ -77,8 +75,6 @@ OS_DBUS_SERVICES_DIR="${EAM_PREFIX}/share/dbus-1/services"
 OS_HELP_DIR="${EAM_PREFIX}/share/help"
 # Knowledge app data.
 OS_EKN_DATA_DIR="${EAM_PREFIX}/share/ekn/data"
-# Knowledge app manifest.
-OS_EKN_MANIFEST_DIR="${EAM_PREFIX}/share/ekn/manifest"
 # Shell search provider directory.
 OS_SHELL_SEARCH_DIR="${EAM_PREFIX}/share/gnome-shell/search-providers"
 # KDE help directory.
@@ -104,7 +100,6 @@ print_config ()
     echo "APP_DBUS_SERVICES_SUBDIR=$APP_DBUS_SERVICES_SUBDIR"
     echo "APP_HELP_SUBDIR=$APP_HELP_SUBDIR"
     echo "APP_EKN_DATA_SUBDIR=$APP_EKN_DATA_SUBDIR"
-    echo "APP_EKN_MANIFEST_SUBDIR=$APP_EKN_MANIFEST_SUBDIR"
     echo "APP_SHELL_SEARCH_SUBDIR=$APP_SHELL_SEARCH_SUBDIR"
     echo "APP_KDE_HELP_SUBDIR=$APP_KDE_HELP_SUBDIR"
     echo "APP_KDE4_SUBDIR=$APP_KDE4_SUBDIR"
@@ -116,7 +111,6 @@ print_config ()
     echo "OS_HELP_DIR=$OS_HELP_DIR"
     echo "OS_DBUS_SERVICES_DIR=$OS_DBUS_SERVICES_DIR"
     echo "OS_EKN_DATA_DIR=$OS_EKN_DATA_DIR"
-    echo "OS_EKN_MANIFEST_DIR=$OS_EKN_MANIFEST_DIR"
     echo "OS_SHELL_SEARCH_DIR=$OS_SHELL_SEARCH_DIR"
     echo "OS_KDE_HELP_DIR=$OS_KDE_HELP_DIR"
     echo "OS_KDE4_DIR=$OS_KDE4_DIR"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -314,7 +314,6 @@ create_symbolic_links ()
 
     ekn_data_symbolic_link "${appid}"
 
-    symbolic_links "${EAM_PREFIX}/${appid}/${APP_EKN_MANIFEST_SUBDIR}" "${OS_EKN_MANIFEST_DIR}"
     symbolic_links "${EAM_PREFIX}/${appid}/${APP_GSETTINGS_SUBDIR}" "${OS_GSETTINGS_DIR}"
     symbolic_links "${EAM_PREFIX}/${appid}/${APP_SHELL_SEARCH_SUBDIR}" "${OS_SHELL_SEARCH_DIR}"
     symbolic_links "${EAM_PREFIX}/${appid}/${APP_KDE_HELP_SUBDIR}" "${OS_KDE_HELP_DIR}"
@@ -361,7 +360,6 @@ delete_symbolic_links ()
     symbolic_links_delete "${EAM_PREFIX}/${appid}/${APP_DBUS_SERVICES_SUBDIR}" "${OS_DBUS_SERVICES_DIR}"
     symbolic_links_delete "${EAM_PREFIX}/${appid}/${APP_HELP_SUBDIR}" "${OS_HELP_DIR}"
     symbolic_links_delete "${EAM_PREFIX}/${appid}/${APP_EKN_DATA_SUBDIR}" "${OS_EKN_DATA_DIR}"
-    symbolic_links_delete "${EAM_PREFIX}/${appid}/${APP_EKN_MANIFEST_SUBDIR}" "${OS_EKN_MANIFEST_DIR}"
     symbolic_links_delete "${EAM_PREFIX}/${appid}/${APP_GSETTINGS_SUBDIR}" "${OS_GSETTINGS_DIR}"
     symbolic_links_delete "${EAM_PREFIX}/${appid}/${APP_SHELL_SEARCH_SUBDIR}" "${OS_SHELL_SEARCH_DIR}"
     symbolic_links_delete "${EAM_PREFIX}/${appid}/${APP_KDE_HELP_SUBDIR}" "${OS_KDE_HELP_DIR}"
@@ -414,9 +412,8 @@ create_os_directories ()
         "${OS_BIN_DIR}" "${OS_DESKTOP_FILES_DIR}" \
         "${OS_DESKTOP_ICONS_DIR}" "${OS_GSETTINGS_DIR}" \
         "${OS_DBUS_SERVICES_DIR}" "${OS_HELP_DIR}" \
-        "${OS_EKN_DATA_DIR}" "${OS_EKN_MANIFEST_DIR}" \
-        "${OS_SHELL_SEARCH_DIR}" "${OS_KDE_HELP_DIR}" \
-        "${OS_KDE4_DIR}"
+        "${OS_EKN_DATA_DIR}" "${OS_SHELL_SEARCH_DIR}" \
+        "${OS_KDE_HELP_DIR}" "${OS_KDE4_DIR}"
     do
         [ -d "${dir}" ] || mkdir --parents "${dir}"
     done

--- a/src/eam-fs-sanity.c
+++ b/src/eam-fs-sanity.c
@@ -14,7 +14,6 @@
 #define DESKTOP_ICONS_SUBDIR "share/icons"
 #define DBUS_SERVICES_SUBDIR "share/dbus-1/services"
 #define EKN_DATA_SUBDIR "share/ekn/data"
-#define EKN_MANIFEST_SUBDIR "share/ekn/manifest"
 #define G_SCHEMAS_SUBDIR "share/glib-2.0/schemas"
 #define XDG_AUTOSTART_SUBDIR "xdg/autostart"
 
@@ -34,7 +33,6 @@ applications_directory_create (void)
   gchar *desktop_icons_dir = g_build_filename (ROOT_DIR, appdir, DESKTOP_ICONS_SUBDIR, NULL);
   gchar *dbus_services_dir = g_build_filename (ROOT_DIR, appdir, DBUS_SERVICES_SUBDIR, NULL);
   gchar *ekn_data_dir = g_build_filename (ROOT_DIR, appdir, EKN_DATA_SUBDIR, NULL);
-  gchar *ekn_manifest_dir = g_build_filename (ROOT_DIR, appdir, EKN_MANIFEST_SUBDIR, NULL);
   gchar *g_schemas_dir = g_build_filename (ROOT_DIR, appdir, G_SCHEMAS_SUBDIR, NULL);
   gchar *xdg_autostart_dir = g_build_filename (ROOT_DIR, appdir, XDG_AUTOSTART_SUBDIR, NULL);
   const gint mode = 0755;
@@ -64,11 +62,6 @@ applications_directory_create (void)
     retval = FALSE;
     goto bail;
   }
-  if (g_mkdir_with_parents (ekn_manifest_dir, mode) != 0) {
-    eam_log_error_message ("Unable to create '%s'", ekn_manifest_dir);
-    retval = FALSE;
-    goto bail;
-  }
   if (g_mkdir_with_parents (g_schemas_dir, mode) != 0) {
     eam_log_error_message ("Unable to create '%s'", g_schemas_dir);
     retval = FALSE;
@@ -86,7 +79,6 @@ bail:
   g_free (desktop_icons_dir);
   g_free (dbus_services_dir);
   g_free (ekn_data_dir);
-  g_free (ekn_manifest_dir);
   g_free (g_schemas_dir);
   g_free (xdg_autostart_dir);
 
@@ -285,7 +277,6 @@ eam_fs_sanity_check (void)
   gchar *desktop_icons_dir = g_build_filename (appdir, DESKTOP_ICONS_SUBDIR, NULL);
   gchar *dbus_services_dir = g_build_filename (appdir, DBUS_SERVICES_SUBDIR, NULL);
   gchar *ekn_data_dir = g_build_filename (appdir, EKN_DATA_SUBDIR, NULL);
-  gchar *ekn_manifest_dir = g_build_filename (appdir, EKN_MANIFEST_SUBDIR, NULL);
   gchar *g_schemas_dir = g_build_filename (appdir, G_SCHEMAS_SUBDIR, NULL);
   gchar *xdg_autostart_dir = g_build_filename (appdir, XDG_AUTOSTART_SUBDIR, NULL);
 
@@ -311,10 +302,6 @@ eam_fs_sanity_check (void)
   }
   if (!g_file_test (ekn_data_dir, G_FILE_TEST_IS_DIR)) {
     eam_log_error_message ("Missing directory: '%s' does not exist", ekn_data_dir);
-    retval = FALSE;
-  }
-  if (!g_file_test (ekn_manifest_dir, G_FILE_TEST_IS_DIR)) {
-    eam_log_error_message ("Missing directory: '%s' does not exist", ekn_manifest_dir);
     retval = FALSE;
   }
   if (!g_file_test (g_schemas_dir, G_FILE_TEST_IS_DIR)) {
@@ -364,7 +351,6 @@ eam_fs_sanity_check (void)
   g_free (desktop_icons_dir);
   g_free (dbus_services_dir);
   g_free (ekn_data_dir);
-  g_free (ekn_manifest_dir);
   g_free (g_schemas_dir);
   g_free (xdg_autostart_dir);
 

--- a/tests/scripts.c
+++ b/tests/scripts.c
@@ -32,7 +32,6 @@ setup_filesystem (void)
   g_mkdir (EAM_PREFIX "/share/dbus-1/services", mode);
   g_mkdir (EAM_PREFIX "/share/ekn", mode);
   g_mkdir (EAM_PREFIX "/share/ekn/data", mode);
-  g_mkdir (EAM_PREFIX "/share/ekn/manifest", mode);
   g_mkdir (EAM_PREFIX "/share/glib-2.0", mode);
   g_mkdir (EAM_PREFIX "/share/glib-2.0/schemas", mode);
   g_mkdir (EAM_PREFIX "/share/icons", mode);


### PR DESCRIPTION
Newer knowledge bundles do not ship with the manifest, and older
bundles can still function post 2.3 without the manifest symlinked.

So we can drop all the code.
[endlessm/eos-sdk#2661]
