### PR TITLE
scripts: Add a FS consistency check

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -391,6 +391,12 @@ check_args_minimum_number ()
 # installation time and not just at daemon init.
 create_os_directories ()
 {
+    # The consistency of the file system is only checked at start up,
+    # but the directory could go away in the middle of a script run.
+    if [ ! -d ${EAM_PREFIX} ]; then
+        exit_error "create_os_directories: Missing EAM_PREFIX top-level directory"
+    fi
+
     for dir in \
         "${OS_BIN_DIR}" "${OS_DESKTOP_FILES_DIR}" \
         "${OS_DESKTOP_ICONS_DIR}" "${OS_GSETTINGS_DIR}" \


### PR DESCRIPTION
The EAM_PREFIX directory could exist by the time the app manager is
started, but it could go away in between activation and script runs.

[endlessm/eos-shell#3571]
