### PR TITLE
App Manager: Fixed segfault on cancelling the app installs

### DIFF
--- a/src/eam-service.c
+++ b/src/eam-service.c
@@ -648,9 +648,10 @@ eam_remote_transaction_cancel (EamRemoteTransaction *remote)
 {
   eam_log_info_message ("Transaction '%s' was cancelled.", remote->obj_path);
   g_cancellable_cancel (remote->cancellable);
-  eam_remote_transaction_free (remote);
 
   eam_service_pop_busy (remote->service);
+
+  eam_remote_transaction_free (remote);
 }
 
 static void


### PR DESCRIPTION
We freed the object before calling one of its private members, causing
the exceptions so only a small change to the ordering was needed.

[endlessm/eos-shell#5167]
