### PR TITLE
App Manager: Enabled delta updates by default

### DIFF
--- a/data/eam-default.cfg.in
+++ b/data/eam-default.cfg.in
@@ -6,4 +6,4 @@ protocolversion = v1
 scriptdir = @pkglibexecdir@
 gpgkeyring = @pkgdatadir@/eos-keyring.gpg
 timeout = 300
-deltaupdates = false
+deltaupdates = true


### PR DESCRIPTION
We have enough of the pipeline here now to be able to start testing
delta upgrades so we enable it by default (for now).

[endlessm/eos-shell#5058]
