### PR TITLE
App Manager: Fixed handling of leftover symlinks

### DIFF
--- a/src/eam-fs-sanity.c
+++ b/src/eam-fs-sanity.c
@@ -662,7 +662,7 @@ create_symlink (const char *source,
   /* Try removing the link manually first if we had leftover junk from last
    * install
    */
-  if (faccessat (0, target, R_OK, AT_SYMLINK_NOFOLLOW | AT_EACCESS) == F_OK &&
+  if (faccessat (0, target, F_OK, AT_SYMLINK_NOFOLLOW | AT_EACCESS) == F_OK &&
       unlink(target) == 0)
     {
       eam_log_error_message ("Doing forced cleanup of link: %s!",


### PR DESCRIPTION
If we didn't cleanup all symlinks from previous app install, the app
manager would choke and die but now we do a forced replacement. The
proper fix for this is to ensure that we don't leave any files behind
but at this point anyone that uninstalled apps with the old code would
have junk leftover so for now, this "forced removal" approach is
preferred.

[endlessm/eos-shell#5243]
