### PR TITLE
fs: don't abort when failing to remove directory

### DIFF
--- a/src/eam-fs-sanity.c
+++ b/src/eam-fs-sanity.c
@@ -892,8 +892,10 @@ rmsymlinks_recursive (const char *appid,
       if (!rmsymlinks_recursive (appid, path))
         return FALSE;
 
-      if (rmdir (path) != 0)
-        return FALSE;
+      /* Try to cleanup empty directories that had links.
+       * We intentionally ignore errors.
+       */
+      rmdir (path);
     }
   }
 


### PR DESCRIPTION
The rmdir() call is only there to clean up empty directories that had
symlinks. We should not abort the symlink pruning when that fails, since
it's an expected case.
The scripts used to handle this with rmdir --ignore-fail-on-non-empty so
this is a regression from the scripts conversion.

[endlessm/eos-shell#5249]
