### PR TITLE
Improve tab completion for eamctl

### DIFF
--- a/tools/completion/eamctl
+++ b/tools/completion/eamctl
@@ -20,6 +20,11 @@ __eamctl_app() {
           return 0
           ;;
 
+        app-info|install|uninstall|update)
+          COMPREPLY=($(compgen -W "`eamctl list-apps`" -- "${COMP_WORDS[2]}"))
+          return 0
+          ;;
+
         *)
           COMPREPLY=()
           return 0


### PR DESCRIPTION
Use the list of apps to complete the arguments for various eamctl
sub-commands.

[endlessm/eos-shell#5374]
