### PR TITLE
migrate-bundles: use ConditionNeedsUpdate=/var

### DIFF
--- a/data/eos-app-manager-migrate-bundles.service.in
+++ b/data/eos-app-manager-migrate-bundles.service.in
@@ -3,7 +3,7 @@ Description=Migrate old application bundle installations
 Documentation=man:eamd(8)
 After=local-fs.target
 Before=systemd-update-done.service
-ConditionNeedsUpdate=/etc
+ConditionNeedsUpdate=/var
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
That's where the bundles live, so this is a bit more correct.

[endlessm/eos-shell#5426]
