### PR TITLE
fs-sanity: Fix another copy/paste typo in the binary symlink code

### DIFF
--- a/src/eam-fs-sanity.c
+++ b/src/eam-fs-sanity.c
@@ -682,7 +682,7 @@ make_binary_symlink (const char *prefix,
 
   if (symlink (bin, path) != 0 && errno != EEXIST)
     return FALSE;
-  if (symlink (path, app_dir) != 0 && errno != EEXIST)
+  if (symlink (path, app_path) != 0 && errno != EEXIST)
     return FALSE;
 
   return TRUE;


### PR DESCRIPTION
This was putting the symlink to the binary file in the wrong spot. I
don't understand how we ever saw this as working, to be honest...

[endlessm/eos-shell#5414]
