### PR TITLE
fs-sanity: Don't ever skip symlinking apps

### DIFF
--- a/src/eam-fs-sanity.c
+++ b/src/eam-fs-sanity.c
@@ -992,9 +992,6 @@ eam_fs_ensure_symlink_farm_for_prefix (const char *prefix)
     if (!eam_fs_is_app_dir (epath))
       continue;
 
-    if (g_file_test (tpath, G_FILE_TEST_IS_SYMLINK))
-      continue;
-
     ret = eam_fs_create_symlinks (prefix, fn) && ret;
   }
 


### PR DESCRIPTION
Previously, since we were running this on every boot, we implemented an optimization to skip apps that seem to already exist.

Recently, we realized this is racy: it's possible for the symlink of the app dir to get created, but not have a "full deployment" of all the symlinks. Now that we're using systemd's upgrade system to run this script, just remove this optimization.

[endlessm/eos-shell#5446]
