### PR TITLE
migrate-bundles: do not use DefaultDependencies for the service

### DIFF
--- a/data/eos-app-manager-migrate-bundles.service.in
+++ b/data/eos-app-manager-migrate-bundles.service.in
@@ -1,8 +1,10 @@
 [Unit]
 Description=Migrate old application bundle installations
 Documentation=man:eamd(8)
-After=local-fs.target
-Before=systemd-update-done.service
+DefaultDependencies=false
+Conflicts=shutdown.target
+After=local-fs.target systemd-journald.socket
+Before=systemd-update-done.service shutdown.target graphical.target
 ConditionNeedsUpdate=/var
 
 [Service]


### PR DESCRIPTION
This needs not to have a dependency on basic.target to avoid cycles.
Use DefaultDependencies=false and manually remove basic.target from
After.

[endlessm/eos-shell#5446]
