### PR TITLE
data: Use https to access app server

### DIFF
--- a/data/eos-app-manager.ini.in
+++ b/data/eos-app-manager.ini.in
@@ -6,7 +6,7 @@ SecondaryStorage = @localstatedir@/endless-extra
 GpgKeyring = @pkgdatadir@/eos-keyring.gpg
 
 [Repository]
-ServerUrl = http://appupdates.endlessm.com
+ServerUrl = https://appupdates.endlessm.com
 ApiVersion = v1
 EnableDeltaUpdates = true
 


### PR DESCRIPTION
The app servers have been providing apps securely over https since the
beginning, so change the configuration defaults to use that.

[endlessm/eos-shell#5508]
