### PR TITLE
utils: Use g_subprocess_get_successful() in run_cmd()

### DIFF
--- a/src/eam-utils.c
+++ b/src/eam-utils.c
@@ -97,7 +97,7 @@ run_cmd (const char * const *argv)
     return FALSE;
   }
 
-  return g_subprocess_get_exit_status (sub) == 0;
+  return g_subprocess_get_successful (sub);
 }
 
 gboolean


### PR DESCRIPTION
g_subprocess_get_successful() checks both WIFEXITED and WIFEXITSTATUS
and returns a boolean, which is all we care about. This also avoids a
CRITICAL message from g_subprocess_get_exit_status() if WIFEXITED is
false.

[endlessm/eos-shell#5558]
