### PR TITLE
Drop the checksum verification of bundles

### DIFF
--- a/src/eam-install.h
+++ b/src/eam-install.h
@@ -47,8 +47,6 @@ void                    eam_install_set_bundle_file     (EamInstall *install,
                                                          const char *path);
 void                    eam_install_set_signature_file  (EamInstall *install,
                                                          const char *path);
-void                    eam_install_set_checksum_file   (EamInstall *install,
-                                                         const char *path);
 
 const char *            eam_install_get_app_id          (EamInstall *install);
 

--- a/src/eam-transaction-dbus.c
+++ b/src/eam-transaction-dbus.c
@@ -106,7 +106,7 @@ handle_transaction_method_call (GDBusConnection *connection,
   eam_log_info_message ("Received method '%s' on transaction interface", method);
 
   if (g_strcmp0 (method, "CompleteTransaction") == 0) {
-    const char *bundle_path = NULL, *signature_path = NULL, *checksum_path = NULL;
+    const char *bundle_path = NULL, *signature_path = NULL;
     const char *storage_type = NULL;
     GVariant *properties;
     GVariantDict dict;
@@ -117,7 +117,6 @@ handle_transaction_method_call (GDBusConnection *connection,
     g_variant_dict_lookup (&dict, "StorageType", "&s", &storage_type);
     g_variant_dict_lookup (&dict, "BundlePath", "&s", &bundle_path);
     g_variant_dict_lookup (&dict, "SignaturePath", "&s", &signature_path);
-    g_variant_dict_lookup (&dict, "ChecksumPath", "&s", &checksum_path);
 
     if (bundle_path != NULL && *bundle_path != '\0') {
       eam_log_info_message ("Setting bundle path to '%s' for transaction '%s'",
@@ -141,7 +140,6 @@ handle_transaction_method_call (GDBusConnection *connection,
 
         eam_install_set_bundle_file (install, bundle_path);
         eam_install_set_signature_file (install, signature_path);
-        eam_install_set_checksum_file (install, checksum_path);
       }
       else if (EAM_IS_UPDATE (remote->transaction)) {
         EamUpdate *update = EAM_UPDATE (remote->transaction);
@@ -150,7 +148,6 @@ handle_transaction_method_call (GDBusConnection *connection,
 
         eam_update_set_bundle_file (update, bundle_path);
         eam_update_set_signature_file (update, signature_path);
-        eam_update_set_checksum_file (update, checksum_path);
       }
       else {
         eam_log_error_message ("Completion of transaction is not update nor install type.");

--- a/src/eam-update.h
+++ b/src/eam-update.h
@@ -47,8 +47,6 @@ void                    eam_update_set_bundle_file      (EamUpdate      *update,
                                                          const char     *path);
 void                    eam_update_set_signature_file   (EamUpdate      *update,
                                                          const char     *path);
-void                    eam_update_set_checksum_file    (EamUpdate      *update,
-                                                         const char     *path);
 
 const char *            eam_update_get_app_id           (EamUpdate  *update);
 

--- a/src/eam-utils.c
+++ b/src/eam-utils.c
@@ -22,7 +22,6 @@
 #include "eam-log.h"
 
 #define BUNDLE_SIGNATURE_EXT ".asc"
-#define BUNDLE_HASH_EXT ".sha256"
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FILE, fclose)
 
@@ -65,19 +64,6 @@ verify_checksum_hash (const char    *source_file,
   const char *hash = g_checksum_get_string (checksum);
 
   return (g_ascii_strncasecmp (checksum_str, hash, hash_len) == 0);
-}
-
-gboolean
-eam_utils_verify_checksum (const char *source_file,
-                           const char *checksum_file)
-{
-  g_autofree char *checksum_str;
-  gsize checksum_len;
-
-  if (!g_file_get_contents (checksum_file, &checksum_str, &checksum_len, NULL))
-    return FALSE;
-
-  return verify_checksum_hash (source_file, checksum_str, checksum_len, G_CHECKSUM_SHA256);
 }
 
 static gboolean

--- a/src/eam-utils.h
+++ b/src/eam-utils.h
@@ -9,8 +9,6 @@
 
 G_BEGIN_DECLS
 
-gboolean        eam_utils_verify_checksum       (const char *source_file,
-                                                 const char *checksum_file);
 gboolean        eam_utils_verify_signature      (const char *source_file,
                                                  const char *signature_file);
 

--- a/tools/eam-command-update.c
+++ b/tools/eam-command-update.c
@@ -21,14 +21,12 @@
 
 static char *opt_prefix;
 static char *opt_asc_file;
-static char *opt_sha_file;
 static char **opt_appid;
 static char *opt_storage_type;
 
 static const GOptionEntry install_entries[] = {
  { "prefix", 0, 0, G_OPTION_ARG_FILENAME, &opt_prefix, "Prefix to use when updating", "DIRECTORY" },
  { "signature-file", 's', 0, G_OPTION_ARG_FILENAME, &opt_asc_file, "Path to the ASC file", "FILE" },
- { "checksum-file", 'c', 0, G_OPTION_ARG_FILENAME, &opt_sha_file, "Path to the SHA file", "FILE" },
  { "storage-type", 'S', 0, G_OPTION_ARG_STRING, &opt_storage_type, "Storage type ('primary' or 'secondary')", "TYPE" },
  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_appid, "Application id", "APPID" },
  { NULL },
@@ -98,17 +96,6 @@ eam_command_update (int argc, char *argv[])
     }
   }
 
-  if (opt_sha_file == NULL) {
-    g_autofree char *dirname = g_path_get_dirname (bundle_file);
-    g_autofree char *filename = g_strconcat (appid, ".sha256", NULL);
-    opt_sha_file = g_build_filename (dirname, filename, NULL);
-
-    if (!g_file_test (opt_sha_file, G_FILE_TEST_EXISTS)) {
-      g_printerr ("No checksum file found. Use --checksum-file to specify the checksum file.\n");
-      return EXIT_FAILURE;
-    }
-  }
-
   /* If we are being called by a privileged user, then we bypass the
    * daemon entirely, because we have enough privileges.
    */
@@ -130,7 +117,6 @@ eam_command_update (int argc, char *argv[])
 
     eam_update_set_bundle_file (update, bundle_file);
     eam_update_set_signature_file (update, opt_asc_file);
-    eam_update_set_checksum_file (update, opt_sha_file);
 
     g_autoptr(GError) error = NULL;
     eam_transaction_run_sync (EAM_TRANSACTION (update), NULL, &error);
@@ -209,7 +195,6 @@ eam_command_update (int argc, char *argv[])
     g_variant_builder_add (&opts, "{sv}", "StorageType", g_variant_new_string (opt_storage_type));
   g_variant_builder_add (&opts, "{sv}", "BundlePath", g_variant_new_string (bundle_file));
   g_variant_builder_add (&opts, "{sv}", "SignaturePath", g_variant_new_string (opt_asc_file));
-  g_variant_builder_add (&opts, "{sv}", "ChecksumPath", g_variant_new_string (opt_sha_file));
 
   gboolean retval = FALSE;
   eos_app_manager_transaction_call_complete_transaction_sync (transaction,


### PR DESCRIPTION
The checksum verification is just meant to be used to verify that the
bundle file has been downloaded properly; for verification of origin,
we use the GPG signature, which is a much stronger guarantee than a
SHA256 digest.

[endlessm/eos-shell#5793]
