### PR TITLE
Fix symlink handling with SD card

### DIFF
--- a/data/eos-app-manager-migrate-bundles.service.in
+++ b/data/eos-app-manager-migrate-bundles.service.in
@@ -6,6 +6,7 @@ Conflicts=shutdown.target
 After=local-fs.target systemd-journald.socket
 Before=systemd-update-done.service shutdown.target graphical.target
 ConditionNeedsUpdate=/var
+RequiresMountsFor=/var/endless /var/endless-extra
 
 [Service]
 Type=oneshot

--- a/data/eos-app-manager-migrate-bundles.service.in
+++ b/data/eos-app-manager-migrate-bundles.service.in
@@ -13,4 +13,4 @@ ExecStart=@bindir@/eamctl ensure-symlink-farm
 User=@EAM_USER@
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
If the symlink farm is created before the SD card is mounted at /var/endless-extra, the apps will disappear to the user.

https://phabricator.endlessm.com/T12747
